### PR TITLE
[EXPERIMENTAL] Bring back gem tracking

### DIFF
--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -40,6 +40,7 @@ module Coverband
       def self.reset
         @@previous_coverage = {}
         @@project_directory = File.expand_path(Coverband.configuration.root)
+        @@project_directories = Coverband.configuration.all_root_paths.map { |path| File.expand_path(path) }
         @@ignore_patterns = Coverband.configuration.ignore
       end
 
@@ -55,7 +56,7 @@ module Coverband
           # would slow down the performance.
           ###
           next unless @@ignore_patterns.none? { |pattern| file.match(pattern) } &&
-            file.start_with?(@@project_directory)
+            @@project_directories.any? { |path| file.start_with?(path) }
 
           # This handles Coverage branch support, setup by default in
           # simplecov 0.18.x

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -222,8 +222,8 @@ module Coverband
     def all_root_paths
       return @all_root_paths if @all_root_paths
 
-      @all_root_paths = Coverband.configuration.root_paths.dup
-      @all_root_paths << "#{Coverband.configuration.current_root}/"
+      @all_root_paths = ["#{Coverband.configuration.current_root}/"]
+      @all_root_paths += Coverband.configuration.root_paths
       @all_root_paths
     end
 


### PR DESCRIPTION
To use gem tracking, simply add the gems root to root_paths